### PR TITLE
Add Retry/DLQ multiplexing

### DIFF
--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/bsm/sarama-cluster"
 	"github.com/uber-go/kafka-client/internal/consumer"
-	"githubcom/uber-go/kafka-client/kafka"
+	"github.com/uber-go/kafka-client/kafka"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )

--- a/internal/consumer/clusterConsumer_test.go
+++ b/internal/consumer/clusterConsumer_test.go
@@ -85,7 +85,7 @@ func (s *ClusterConsumerTestSuite) SetupTest() {
 	s.msgCh = make(chan kafka.Message, 10)
 	s.saramaConsumer = newMockSaramaConsumer()
 	s.dlqProducer = newMockDLQProducer()
-	s.topicConsumer = NewTopicConsumer(topic.Name, s.msgCh, s.saramaConsumer, s.dlqProducer, s.options, tally.NoopScope, s.logger)
+	s.topicConsumer = NewTopicConsumer(topic.Name, s.msgCh, s.saramaConsumer, s.dlqProducer, false, s.options, tally.NoopScope, s.logger)
 	s.Equal(topic.Name, s.topicConsumer.Topic())
 	s.consumer = NewClusterConsumer(topic.Cluster, s.saramaConsumer, map[string]*TopicConsumer{s.topic: s.topicConsumer}, tally.NoopScope, s.logger)
 }

--- a/internal/consumer/clusterConsumer_test.go
+++ b/internal/consumer/clusterConsumer_test.go
@@ -85,8 +85,7 @@ func (s *ClusterConsumerTestSuite) SetupTest() {
 	s.msgCh = make(chan kafka.Message, 10)
 	s.saramaConsumer = newMockSaramaConsumer()
 	s.dlqProducer = newMockDLQProducer()
-	s.topicConsumer = NewTopicConsumer(topic.Name, s.msgCh, s.saramaConsumer, s.dlqProducer, false, s.options, tally.NoopScope, s.logger)
-	s.Equal(topic.Name, s.topicConsumer.Topic())
+	s.topicConsumer = NewTopicConsumer(Topic{topic, TopicTypeDefaultQ}, s.msgCh, s.saramaConsumer, s.dlqProducer, s.options, tally.NoopScope, s.logger)
 	s.consumer = NewClusterConsumer(topic.Cluster, s.saramaConsumer, map[string]*TopicConsumer{s.topic: s.topicConsumer}, tally.NoopScope, s.logger)
 }
 

--- a/internal/consumer/dlq.go
+++ b/internal/consumer/dlq.go
@@ -50,6 +50,19 @@ type (
 		Add(m kafka.Message) error
 	}
 
+	// retryDLQMultiplexer multiplexes an DLQ add between distinct Retry and DLQ topics
+	retryDLQMultiplexer struct {
+		// retryCountThreshold is the threshold that is used to determine whether a message
+		// goes to retryTopic or dlqTopic
+		retryCountThreshold int64
+		// retryTopic is topic that acts as a retry queue.
+		// messages with retry count < the retry count threshold in the multiplexer will be sent to this topic.
+		retryTopic DLQ
+		// dlqTopic is topic that acts as a dead letter queue.
+		// messages with retry count >= the retry count threshold in the multiplexer will be sent to this topic.
+		dlqTopic DLQ
+	}
+
 	// bufferedErrorTopic is a client side abstraction for an error topic on the Kafka cluster.
 	// This library uses the error topic as a base abstraction for retry and dlq topics.
 	//
@@ -180,4 +193,48 @@ func (d *bufferedErrorTopic) newSaramaMessage(key, value []byte, responseC chan 
 		Value:    sarama.ByteEncoder(value),
 		Metadata: responseC,
 	}
+}
+
+// NewRetryDLQMultiplexer returns a DLQ that will produce messages to retryTopic or dlqTopic depending on
+// the threshold.
+//
+// Messages that are added to this DLQ will be sent to retryTopic if the retry count of the message is
+// < the threshold.
+// Else, it will go to the dlqTopic.
+func NewRetryDLQMultiplexer(retryTopic, dlqTopic DLQ, threshold int64) DLQ {
+	return &retryDLQMultiplexer{
+		retryCountThreshold: threshold,
+		retryTopic:          retryTopic,
+		dlqTopic:            dlqTopic,
+	}
+}
+
+// Add sends a kafka message to the retry topic or dlq topic depending on the retry count in the message.
+//
+// If the message RetryCount is greater than or equal to the retryCountTreshold in the multiplexer,
+// the message will be sent to the retry topic.
+// Else, it will be sent to the dlq topic.
+func (d *retryDLQMultiplexer) Add(m kafka.Message) error {
+	if m.RetryCount() >= d.retryCountThreshold {
+		return d.dlqTopic.Add(m)
+	}
+	return d.retryTopic.Add(m)
+}
+
+// Start retryDLQMultiplexer will start the retry and dlq buffered dlq producers.
+func (d *retryDLQMultiplexer) Start() error {
+	if err := d.retryTopic.Start(); err != nil {
+		return err
+	}
+	if err := d.dlqTopic.Start(); err != nil {
+		d.retryTopic.Stop()
+		return err
+	}
+	return nil
+}
+
+// Stop closes the resources held by the retryTopic and dlqTopic.
+func (d *retryDLQMultiplexer) Stop() {
+	d.dlqTopic.Stop()
+	d.retryTopic.Stop()
 }

--- a/internal/consumer/dlq_test.go
+++ b/internal/consumer/dlq_test.go
@@ -202,7 +202,7 @@ type DLQMultiplexerTestSuite struct {
 	msg         *mockMessage
 	retry       *mockDLQProducer
 	dlq         *mockDLQProducer
-	multiplexer *retryDLQMultiplexer
+	multiplexer *dlqMultiplexer
 }
 
 func TestDLQMultiplexerTestSuite(t *testing.T) {
@@ -213,7 +213,7 @@ func (s *DLQMultiplexerTestSuite) SetupTest() {
 	s.msg = new(mockMessage)
 	s.retry = newMockDLQProducer()
 	s.dlq = newMockDLQProducer()
-	s.multiplexer = &retryDLQMultiplexer{
+	s.multiplexer = &dlqMultiplexer{
 		retryCountThreshold: 3,
 		retryTopic:          s.retry,
 		dlqTopic:            s.dlq,

--- a/internal/consumer/message.go
+++ b/internal/consumer/message.go
@@ -67,14 +67,15 @@ func newMessage(scm *sarama.ConsumerMessage, ackID ackID, ackMgr *ackManager, dl
 }
 
 // Key is a mutable reference to the message's key
-func (m *Message) Key() []byte {
-	result := make([]byte, len(m.msg.Key))
+func (m *Message) Key() (key []byte) {
 	if m.metadata.Data != nil {
-		copy(result, m.metadata.Data)
+		key = make([]byte, len(m.metadata.Data))
+		copy(key, m.metadata.Data)
 	} else {
-		copy(result, m.msg.Key)
+		key = make([]byte, len(m.msg.Key))
+		copy(key, m.msg.Key)
 	}
-	return result
+	return
 }
 
 // Value is a mutable reference to the message's value

--- a/internal/consumer/message_test.go
+++ b/internal/consumer/message_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package consumer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/kafka-client/kafka"
+)
+
+type MessageTestSuite struct {
+	suite.Suite
+	message    *Message
+	dlqMessage *Message
+}
+
+var _ kafka.Message = (*Message)(nil)
+
+func TestMessageTestSuite(t *testing.T) {
+	suite.Run(t, new(MessageTestSuite))
+}
+
+func (s *MessageTestSuite) SetupTest() {
+	saramaMessage := &sarama.ConsumerMessage{
+		Key:       []byte("key1"),
+		Value:     []byte("value1"),
+		Topic:     "topic1",
+		Partition: 1,
+		Offset:    1,
+		Timestamp: time.Unix(1, 0),
+	}
+	metadata := &DLQMetadata{
+		RetryCount:  1,
+		Topic:       "topic2",
+		Partition:   2,
+		Offset:      2,
+		TimestampNs: 100,
+		Data:        []byte("key2"),
+	}
+	ackID := new(ackID)
+	s.message = newMessage(saramaMessage, *ackID, nil, nil, *newDLQMetadata())
+	s.dlqMessage = newMessage(saramaMessage, *ackID, nil, nil, *metadata)
+}
+
+func (s *MessageTestSuite) TestKey() {
+	s.EqualValues(s.message.msg.Key, s.message.Key())
+	s.EqualValues(s.dlqMessage.metadata.Data, s.dlqMessage.Key())
+}
+
+func (s *MessageTestSuite) TestValue() {
+	s.EqualValues(s.message.msg.Value, s.message.Value())
+	s.EqualValues(s.dlqMessage.msg.Value, s.dlqMessage.Value())
+}
+
+func (s *MessageTestSuite) TestTopic() {
+	s.EqualValues(s.message.msg.Topic, s.message.Topic())
+	s.EqualValues(s.dlqMessage.metadata.Topic, s.dlqMessage.Topic())
+}
+
+func (s *MessageTestSuite) TestPartition() {
+	s.EqualValues(s.message.msg.Partition, s.message.Partition())
+	s.EqualValues(s.dlqMessage.metadata.Partition, s.dlqMessage.Partition())
+}
+
+func (s *MessageTestSuite) TestOffset() {
+	s.EqualValues(s.message.msg.Offset, s.message.Offset())
+	s.EqualValues(s.dlqMessage.metadata.Offset, s.dlqMessage.Offset())
+}
+
+func (s *MessageTestSuite) TestTimestamp() {
+	s.EqualValues(s.message.msg.Timestamp, s.message.Timestamp())
+	s.EqualValues(time.Unix(0, s.dlqMessage.metadata.TimestampNs), s.dlqMessage.Timestamp())
+}
+
+func (s *MessageTestSuite) TestRetryCount() {
+	s.EqualValues(s.message.metadata.RetryCount, s.message.RetryCount())
+	s.EqualValues(s.dlqMessage.metadata.RetryCount, s.dlqMessage.RetryCount())
+}

--- a/internal/consumer/mocks_test.go
+++ b/internal/consumer/mocks_test.go
@@ -246,6 +246,12 @@ func (m *mockPartitionedConsumer) isClosed() bool {
 	return atomic.LoadInt64(&m.closed) == 1
 }
 
+func (m *mockPartitionedConsumer) AsyncClose() {}
+
+func (m *mockPartitionedConsumer) Errors() <-chan *sarama.ConsumerError {
+	return nil
+}
+
 // Messages returns the read channel for the messages that are returned by
 // the broker.
 func (m *mockPartitionedConsumer) Messages() <-chan *sarama.ConsumerMessage {

--- a/internal/consumer/mocks_test.go
+++ b/internal/consumer/mocks_test.go
@@ -57,7 +57,6 @@ type (
 	mockSaramaClient struct {
 		closed int32
 	}
-
 	mockSaramaProducer struct {
 		closed   int32
 		inputC   chan *sarama.ProducerMessage

--- a/internal/consumer/types.go
+++ b/internal/consumer/types.go
@@ -24,6 +24,16 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/bsm/sarama-cluster"
 	"github.com/uber-go/kafka-client/internal/util"
+	"github.com/uber-go/kafka-client/kafka"
+)
+
+const (
+	// TopicTypeDefaultQ is an enum for a consumer that reads from a the default/original topic.
+	TopicTypeDefaultQ TopicType = iota + 1
+	// TopicTypeRetryQ is a enum for a consumer that reads from a RetryQ topic.
+	TopicTypeRetryQ
+	// TopicTypeDLQ is a enum for a consumer that reads from a DLQ topic.
+	TopicTypeDLQ
 )
 
 type (
@@ -66,6 +76,15 @@ type (
 		NewSaramaProducer func(sarama.Client) (sarama.AsyncProducer, error)
 		NewSaramaConsumer func([]string, string, []string, *cluster.Config) (SaramaConsumer, error)
 		NewSaramaClient   func([]string, *sarama.Config) (sarama.Client, error)
+	}
+
+	// TopicType is an enum for the type of topic: TopicTypeDefaultQ, TopicTypeRetryQ, TopicTypeDLQ.
+	TopicType int
+
+	// Topic is an internal wrapper around kafka.ConsumerTopic
+	Topic struct {
+		kafka.ConsumerTopic
+		TopicType
 	}
 )
 

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -51,9 +51,9 @@ type (
 	// the topic to consume from and the DLQ topic to send nacked messages to.
 	ConsumerTopic struct {
 		Topic
-		Retry Topic
+		Retry      Topic
 		RetryCount int64
-		DLQ Topic
+		DLQ        Topic
 	}
 
 	// ConsumerTopicList is a list of consumer topics

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -51,6 +51,8 @@ type (
 	// the topic to consume from and the DLQ topic to send nacked messages to.
 	ConsumerTopic struct {
 		Topic
+		Retry Topic
+		RetryCount int64
 		DLQ Topic
 	}
 

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -51,9 +51,9 @@ type (
 	// the topic to consume from and the DLQ topic to send nacked messages to.
 	ConsumerTopic struct {
 		Topic
-		Retry      Topic
-		RetryCount int64
+		RetryQ     Topic
 		DLQ        Topic
+		MaxRetries int64
 	}
 
 	// ConsumerTopicList is a list of consumer topics


### PR DESCRIPTION
Add producer and consumer multiplexing for retry topic.

As with last few PR, consumerBuilder is untested until features are complete to reduce wasted test writing effort. 