### PR TITLE
Fix metrics in ack mgr

### DIFF
--- a/internal/consumer/ackMgr.go
+++ b/internal/consumer/ackMgr.go
@@ -99,7 +99,7 @@ func newAckManager(maxOutstanding int, scope tally.Scope, logger *zap.Logger) *a
 func (mgr *ackManager) GetAckID(msgSeq int64) (ackID, error) {
 	addr, err := mgr.unackedSeqList.Add(msgSeq)
 	if err != nil {
-		mgr.tally.Counter(metrics.KafkaPartitionGetAckIDErrors)
+		mgr.tally.Counter(metrics.KafkaPartitionGetAckIDErrors).Inc(1)
 		if err != list.ErrCapacity {
 			// list.ErrCapacity is handled gracefully so no need to log error.
 			mgr.logger.Error("GetAckID() error", zap.Int64("rcvdSeq", msgSeq), zap.Error(err))
@@ -110,20 +110,27 @@ func (mgr *ackManager) GetAckID(msgSeq int64) (ackID, error) {
 }
 
 // Ack marks the given msgSeqNum as processed
-func (mgr *ackManager) Ack(id ackID) {
-	err := mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
+func (mgr *ackManager) Ack(id ackID) (err error) {
+	err = mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
 	if err != nil {
-		mgr.tally.Counter(metrics.KafkaPartitionAckErrors)
+		mgr.tally.Counter(metrics.KafkaPartitionAckErrors).Inc(1)
 		mgr.logger.Error("ack error: list remove failed", zap.Error(err))
 	}
+	mgr.tally.Counter(metrics.KafkaPartitionAck).Inc(1)
+	return
 }
 
 // Nack marks the given msgSeqNum as processed, the expectation
 // is for the caller to move the message to an error queue
 // before calling this
-func (mgr *ackManager) Nack(id ackID) {
-	mgr.Ack(id)
-	mgr.tally.Counter(metrics.KafkaPartitionNacks)
+func (mgr *ackManager) Nack(id ackID) (err error) {
+	err = mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
+	if err != nil {
+		mgr.tally.Counter(metrics.KafkaPartitionNackErrors).Inc(1)
+		mgr.logger.Error("nack error: list remove failed", zap.Error(err))
+	}
+	mgr.tally.Counter(metrics.KafkaPartitionNack).Inc(1)
+	return
 }
 
 // CommitLevel returns the seqNum that can be

--- a/internal/consumer/ackMgr.go
+++ b/internal/consumer/ackMgr.go
@@ -112,13 +112,15 @@ func (mgr *ackManager) GetAckID(msgSeq int64) (ackID, error) {
 // Ack marks the given msgSeqNum as processed.
 // Ack always returns nil because the errors are non-actionable and do not affect correctness
 // so we do not want to propagate back to user.
+// Non-actionable errors are visible via "kafka.partition.ackmgr.ack-error" metrics.
 func (mgr *ackManager) Ack(id ackID) error {
 	err := mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
 	if err != nil {
 		mgr.tally.Counter(metrics.KafkaPartitionAckErrors).Inc(1)
 		mgr.logger.Error("ack error: list remove failed", zap.Error(err))
+	} else {
+		mgr.tally.Counter(metrics.KafkaPartitionAck).Inc(1)
 	}
-	mgr.tally.Counter(metrics.KafkaPartitionAck).Inc(1)
 	return nil
 }
 
@@ -127,13 +129,15 @@ func (mgr *ackManager) Ack(id ackID) error {
 // before calling this
 // Nack always returns nil because the errors are non-actionable and do not affect correctness
 // so we do not want to propagate back to user.
+// Non-actionable errors are visible via "kafka.partition.ackmgr.nack-error" metrics.
 func (mgr *ackManager) Nack(id ackID) error {
 	err := mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
 	if err != nil {
 		mgr.tally.Counter(metrics.KafkaPartitionNackErrors).Inc(1)
 		mgr.logger.Error("nack error: list remove failed", zap.Error(err))
+	} else {
+		mgr.tally.Counter(metrics.KafkaPartitionNack).Inc(1)
 	}
-	mgr.tally.Counter(metrics.KafkaPartitionNack).Inc(1)
 	return nil
 }
 

--- a/internal/consumer/ackMgr.go
+++ b/internal/consumer/ackMgr.go
@@ -109,28 +109,32 @@ func (mgr *ackManager) GetAckID(msgSeq int64) (ackID, error) {
 	return newAckID(addr, msgSeq), nil
 }
 
-// Ack marks the given msgSeqNum as processed
-func (mgr *ackManager) Ack(id ackID) (err error) {
-	err = mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
+// Ack marks the given msgSeqNum as processed.
+// Ack always returns nil because the errors are non-actionable and do not affect correctness
+// so we do not want to propagate back to user.
+func (mgr *ackManager) Ack(id ackID) error {
+	err := mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
 	if err != nil {
 		mgr.tally.Counter(metrics.KafkaPartitionAckErrors).Inc(1)
 		mgr.logger.Error("ack error: list remove failed", zap.Error(err))
 	}
 	mgr.tally.Counter(metrics.KafkaPartitionAck).Inc(1)
-	return
+	return nil
 }
 
 // Nack marks the given msgSeqNum as processed, the expectation
 // is for the caller to move the message to an error queue
 // before calling this
-func (mgr *ackManager) Nack(id ackID) (err error) {
-	err = mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
+// Nack always returns nil because the errors are non-actionable and do not affect correctness
+// so we do not want to propagate back to user.
+func (mgr *ackManager) Nack(id ackID) error {
+	err := mgr.unackedSeqList.Remove(id.listAddr, id.msgSeq)
 	if err != nil {
 		mgr.tally.Counter(metrics.KafkaPartitionNackErrors).Inc(1)
 		mgr.logger.Error("nack error: list remove failed", zap.Error(err))
 	}
 	mgr.tally.Counter(metrics.KafkaPartitionNack).Inc(1)
-	return
+	return nil
 }
 
 // CommitLevel returns the seqNum that can be

--- a/internal/consumer/message.go
+++ b/internal/consumer/message.go
@@ -126,8 +126,7 @@ func (m *Message) RetryCount() int64 {
 // Ack acknowledges the message
 func (m *Message) Ack() error {
 	ctx := &m.ctx
-	ctx.ackMgr.Ack(ctx.ackID)
-	return nil
+	return ctx.ackMgr.Ack(ctx.ackID)
 }
 
 // Nack negatively acknowledges the message
@@ -139,8 +138,7 @@ func (m *Message) Nack() error {
 	if err := ctx.dlq.Add(m); err != nil {
 		return err
 	}
-	ctx.ackMgr.Nack(ctx.ackID)
-	return nil
+	return ctx.ackMgr.Nack(ctx.ackID)
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaler for structured logging.

--- a/internal/metrics/defs.go
+++ b/internal/metrics/defs.go
@@ -33,14 +33,16 @@ const (
 	KafkaDLQStopped       = "kafka.dlq.stopped"
 	KafkaDLQMessagesOut   = "kafka.dlq.messages-out"
 	KafkaDLQErrors        = "kafka.dlq.errors"
-	KafkaDLQMetadataError = "kafka.dlq.metadata-errors"
+	KafkaDLQMetadataError = "kafka.dlq.metadata-error"
 
 	KafkaPartitionAckMgrDups     = "kafka.partition.ackmgr.duplicates"
 	KafkaPartitionAckMgrSkipped  = "kafka.partition.ackmgr.skipped"
-	KafkaPartitionAckMgrListFull = "kafka.partition.ackmgr.list-full-errors"
-	KafkaPartitionGetAckIDErrors = "kafka.partition.ackmgr.get-ackid-errors"
-	KafkaPartitionAckErrors      = "kafka.partition.ackmgr.ack-errors"
-	KafkaPartitionNacks          = "kafka.partition.nacks"
+	KafkaPartitionAckMgrListFull = "kafka.partition.ackmgr.list-full-error"
+	KafkaPartitionGetAckIDErrors = "kafka.partition.ackmgr.get-ackid-error"
+	KafkaPartitionAck            = "kafka.partition.ack"
+	KafkaPartitionAckErrors      = "kafka.partition.ackmgr.ack-error"
+	KafkaPartitionNack           = "kafka.partition.nack"
+	KafkaPartitionNackErrors     = "kafka.partition.ackmgr.nack-error"
 	KafkaPartitionRebalance      = "kafka.partition.rebalance"
 )
 


### PR DESCRIPTION
- [bug] a couple counters fail to increment.
- add metrics for ack and nack errors.
- propagate ack/nack errors to user so that they can decide what to do. We currently give a false impression that an ack was successful even if there was an error in the list. 