### PR TITLE
Pin sarama-cluster to cf455bc755fe41ac9bb2861e7a961833d9c2ecc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 v0.1.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed sarama-cluster dependency pin to cf455bc755fe41ac9bb2861e7a961833d9c2ecc3 because we need ResetOffsets method with NPE fix.
 
 
 v0.1.0 (2018-03-05)

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 8c4bed9db9f5629919b9f75f736dc3edbc121197e9f497c3568f760dd7c72e83
-updated: 2018-02-13T14:03:46.42337-08:00
+hash: f7c3d44e2e64af96f794d4944f7792de71dbfd069a6b06088e9eb13ab27b3132
+updated: 2018-03-05T15:45:15.526195-08:00
 imports:
 - name: github.com/bsm/sarama-cluster
-  version: 3001c2453136632aa3219a58ea3795bb584b83b5
+  version: cf455bc755fe41ac9bb2861e7a961833d9c2ecc3
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
@@ -34,7 +34,7 @@ imports:
 - name: github.com/Shopify/sarama
   version: f7be6aa2bc7b2e38edf816b08b582782194a1c02
 - name: github.com/uber-go/tally
-  version: 6c4631652c6aab57c64f65c2e0aaec2e9aae3a64
+  version: 522328b48efad0c6034dba92bf39228694e9d31f
 - name: go.uber.org/atomic
   version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: go.uber.org/multierr
@@ -53,7 +53,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/Shopify/sarama
   version: ^1
 - package: github.com/bsm/sarama-cluster
-  version: ^2
+  version: cf455bc755fe41ac9bb2861e7a961833d9c2ecc3
 - package: github.com/golang/protobuf
   version: ^1
 testImport:


### PR DESCRIPTION
Sarama cluster has not released a new version so pin to the latest version of master that we know is safe because we need the NPE fix for the ResetOffsets function (https://github.com/bsm/sarama-cluster/commit/cf455bc755fe41ac9bb2861e7a961833d9c2ecc3). 

I have [requested](https://github.com/bsm/sarama-cluster/issues/223) that they release a new version of sarama-cluster so I will pin to semver once that is complete. 