### PR TITLE
Fix retry and dlq topic injection via WithRetryTopics and WithDLQTopics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 v0.1.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add WithRetryTopics and WithDLQTopics to inject additional consumers for additional retry or DLQ topics.
 
 
 v0.1.2 (2018-03-07)

--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -112,7 +112,7 @@ func (c *consumerBuilder) build() (*consumer.MultiClusterConsumer, error) {
 	}
 
 	// Add additional topics that may have been injected from WithRangeConsumer option.
-	for _, topic := range c.options.RangeConsumerTopics {
+	for _, topic := range c.options.OtherConsumerTopics {
 		c.addTopicToClusterTopicsMap(topic)
 	}
 

--- a/consumerOptions.go
+++ b/consumerOptions.go
@@ -62,7 +62,7 @@ func (o *rangeConsumersOption) apply(opts *consumer.Options) {
 	}
 }
 
-// WithDLQTopics creates a range consumer for the specified consumer topics.
+// WithDLQTopics creates a range consumer for the specified consumer DLQ topics.
 func WithDLQTopics(topicList kafka.ConsumerTopicList) ConsumerOption {
 	return &dlqTopicsOptions{
 		topicList: topicList,
@@ -79,7 +79,7 @@ func (o *dlqTopicsOptions) apply(opts *consumer.Options) {
 	}
 }
 
-// WithRetryTopics creates a range consumer for the specified consumer topics.
+// WithRetryTopics creates a consumer for the specified consumer Retry topics.
 func WithRetryTopics(topicList kafka.ConsumerTopicList) ConsumerOption {
 	return &retryTopicsOptions{
 		topicList: topicList,

--- a/consumerOptions.go
+++ b/consumerOptions.go
@@ -34,9 +34,18 @@ type (
 	rangeConsumersOption struct {
 		topicList kafka.ConsumerTopicList
 	}
+
+	dlqTopicsOptions struct {
+		topicList kafka.ConsumerTopicList
+	}
+
+	retryTopicsOptions struct {
+		topicList kafka.ConsumerTopicList
+	}
 )
 
 // WithRangeConsumers creates a range consumer for the specified consumer topics.
+// DEPRECATED
 func WithRangeConsumers(topicList kafka.ConsumerTopicList) ConsumerOption {
 	return &rangeConsumersOption{
 		topicList: topicList,
@@ -44,13 +53,45 @@ func WithRangeConsumers(topicList kafka.ConsumerTopicList) ConsumerOption {
 }
 
 func (o *rangeConsumersOption) apply(opts *consumer.Options) {
-	consumerTopicList := make([]consumer.Topic, 0, len(o.topicList))
 	for _, topic := range o.topicList {
-		consumerTopicList = append(consumerTopicList, consumer.Topic{
+		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
 			ConsumerTopic:            topic,
 			TopicType:                consumer.TopicTypeDefaultQ,
 			PartitionConsumerFactory: consumer.NewRangePartitionConsumer,
 		})
 	}
-	opts.RangeConsumerTopics = consumerTopicList
+}
+
+// WithDLQTopics creates a range consumer for the specified consumer topics.
+func WithDLQTopics(topicList kafka.ConsumerTopicList) ConsumerOption {
+	return &dlqTopicsOptions{
+		topicList: topicList,
+	}
+}
+
+func (o *dlqTopicsOptions) apply(opts *consumer.Options) {
+	for _, topic := range o.topicList {
+		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
+			ConsumerTopic:            topic,
+			TopicType:                consumer.TopicTypeDLQ,
+			PartitionConsumerFactory: consumer.NewRangePartitionConsumer,
+		})
+	}
+}
+
+// WithRetryTopics creates a range consumer for the specified consumer topics.
+func WithRetryTopics(topicList kafka.ConsumerTopicList) ConsumerOption {
+	return &retryTopicsOptions{
+		topicList: topicList,
+	}
+}
+
+func (o *retryTopicsOptions) apply(opts *consumer.Options) {
+	for _, topic := range o.topicList {
+		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
+			ConsumerTopic:            topic,
+			TopicType:                consumer.TopicTypeRetryQ,
+			PartitionConsumerFactory: consumer.NewPartitionConsumer,
+		})
+	}
 }

--- a/consumerOptions_test.go
+++ b/consumerOptions_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package kafkaclient
 
 import (

--- a/consumerOptions_test.go
+++ b/consumerOptions_test.go
@@ -1,0 +1,31 @@
+package kafkaclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/kafka-client/internal/consumer"
+	"github.com/uber-go/kafka-client/kafka"
+)
+
+func TestDLQConsumerOptions(t *testing.T) {
+	testTopics := make([]kafka.ConsumerTopic, 0, 10)
+	testTopics = append(testTopics, *new(kafka.ConsumerTopic))
+	testTopics = append(testTopics, *new(kafka.ConsumerTopic))
+	consumerOption := WithDLQTopics(testTopics)
+	options := consumer.DefaultOptions()
+	consumerOption.apply(options)
+	assert.Equal(t, 2, len(options.OtherConsumerTopics))
+	assert.Equal(t, consumer.TopicTypeDLQ, options.OtherConsumerTopics[0].TopicType)
+}
+
+func TestRetryConsumerOptions(t *testing.T) {
+	testTopics := make([]kafka.ConsumerTopic, 0, 10)
+	testTopics = append(testTopics, *new(kafka.ConsumerTopic))
+	testTopics = append(testTopics, *new(kafka.ConsumerTopic))
+	consumerOption := WithRetryTopics(testTopics)
+	options := consumer.DefaultOptions()
+	consumerOption.apply(options)
+	assert.Equal(t, 2, len(options.OtherConsumerTopics))
+	assert.Equal(t, consumer.TopicTypeRetryQ, options.OtherConsumerTopics[0].TopicType)
+}

--- a/internal/consumer/options.go
+++ b/internal/consumer/options.go
@@ -38,7 +38,7 @@ type (
 		RebalanceDwellTime     time.Duration
 		MaxProcessingTime      time.Duration // amount of time a partitioned consumer will wait during a drain
 		ConsumerMode           cluster.ConsumerMode
-		RangeConsumerTopics    []Topic
+		OtherConsumerTopics    []Topic
 	}
 )
 
@@ -53,5 +53,6 @@ func DefaultOptions() *Options {
 		MaxProcessingTime:      250 * time.Millisecond,
 		OffsetPolicy:           sarama.OffsetOldest,
 		ConsumerMode:           cluster.ConsumerModePartitions,
+		OtherConsumerTopics:    make([]Topic, 0, 10),
 	}
 }


### PR DESCRIPTION
Injecting consumers for additional DLQ topics fails to deserialize DLQ metadata because TopicType is set to `TopicTypeDefaultQ`if injecting with `WithRangeConsumer`. This PR adds `WithRetryTopics` and `WithDLQTopics` to ensure that the correct type of topic is created. 

I'm open to removing WithRangeConsumer and cutting 0.2 if we want to keep it clean. 