### PR TITLE
Use DLQ metadata decoder instead of infer decoding from TopicType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 v0.1.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix DLQMetadata decoding to use DLQMetadataDecoder func instead of inferred decoding from TopicType.
 
 
 v0.1.3 (2018-03-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ v0.1.4 (unreleased)
 -------------------
 
 - Fix DLQMetadata decoding to use DLQMetadataDecoder func instead of inferred decoding from TopicType.
+- Fix consumer to use noopDLQ if RetryQ or DLQ in config is empty.
 
 
 v0.1.3 (2018-03-09)

--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -107,8 +107,12 @@ func (c *consumerBuilder) build() (*consumer.MultiClusterConsumer, error) {
 	// build TopicList per cluster
 	for _, consumerTopic := range c.kafkaConfig.TopicList {
 		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: consumerTopic, DLQMetadataDecoder: consumer.NoopDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewPartitionConsumer})
-		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToRetryTopic(consumerTopic), DLQMetadataDecoder: consumer.ProtobufDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewPartitionConsumer})
-		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToDLQTopic(consumerTopic), DLQMetadataDecoder: consumer.ProtobufDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewRangePartitionConsumer})
+		if consumerTopic.RetryQ.Name != "" && consumerTopic.RetryQ.Cluster != "" {
+			c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToRetryTopic(consumerTopic), DLQMetadataDecoder: consumer.ProtobufDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewPartitionConsumer})
+		}
+		if consumerTopic.DLQ.Name != "" && consumerTopic.DLQ.Cluster != "" {
+			c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToDLQTopic(consumerTopic), DLQMetadataDecoder: consumer.ProtobufDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewRangePartitionConsumer})
+		}
 	}
 
 	// Add additional topics that may have been injected from WithRangeConsumer option.

--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -106,9 +106,9 @@ func (c *consumerBuilder) Build() (kafka.Consumer, error) {
 func (c *consumerBuilder) build() (*consumer.MultiClusterConsumer, error) {
 	// build TopicList per cluster
 	for _, consumerTopic := range c.kafkaConfig.TopicList {
-		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: consumerTopic, TopicType: consumer.TopicTypeDefaultQ, PartitionConsumerFactory: consumer.NewPartitionConsumer})
-		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToRetryTopic(consumerTopic), TopicType: consumer.TopicTypeRetryQ, PartitionConsumerFactory: consumer.NewPartitionConsumer})
-		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToDLQTopic(consumerTopic), TopicType: consumer.TopicTypeDLQ, PartitionConsumerFactory: consumer.NewRangePartitionConsumer})
+		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: consumerTopic, DLQMetadataDecoder: consumer.NoopDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewPartitionConsumer})
+		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToRetryTopic(consumerTopic), DLQMetadataDecoder: consumer.ProtobufDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewPartitionConsumer})
+		c.addTopicToClusterTopicsMap(consumer.Topic{ConsumerTopic: topicToDLQTopic(consumerTopic), DLQMetadataDecoder: consumer.ProtobufDLQMetadataDecoder, PartitionConsumerFactory: consumer.NewRangePartitionConsumer})
 	}
 
 	// Add additional topics that may have been injected from WithRangeConsumer option.

--- a/consumerBuilder_test.go
+++ b/consumerBuilder_test.go
@@ -74,6 +74,15 @@ func (s *ConsumerBuilderTestSuite) SetupTest() {
 			},
 			MaxRetries: 1,
 		},
+		{
+			Topic: kafka.Topic{
+				Name:    "topic1",
+				Cluster: "cluster",
+			},
+			RetryQ:     kafka.Topic{},
+			DLQ:        kafka.Topic{},
+			MaxRetries: 1,
+		},
 	})
 	s.resolver = kafka.NewStaticNameResolver(
 		map[string][]string{

--- a/consumerOptions.go
+++ b/consumerOptions.go
@@ -56,7 +56,7 @@ func (o *rangeConsumersOption) apply(opts *consumer.Options) {
 	for _, topic := range o.topicList {
 		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
 			ConsumerTopic:            topic,
-			TopicType:                consumer.TopicTypeDefaultQ,
+			DLQMetadataDecoder:       consumer.NoopDLQMetadataDecoder,
 			PartitionConsumerFactory: consumer.NewRangePartitionConsumer,
 		})
 	}
@@ -73,7 +73,7 @@ func (o *dlqTopicsOptions) apply(opts *consumer.Options) {
 	for _, topic := range o.topicList {
 		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
 			ConsumerTopic:            topic,
-			TopicType:                consumer.TopicTypeDLQ,
+			DLQMetadataDecoder:       consumer.ProtobufDLQMetadataDecoder,
 			PartitionConsumerFactory: consumer.NewRangePartitionConsumer,
 		})
 	}
@@ -90,7 +90,7 @@ func (o *retryTopicsOptions) apply(opts *consumer.Options) {
 	for _, topic := range o.topicList {
 		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
 			ConsumerTopic:            topic,
-			TopicType:                consumer.TopicTypeRetryQ,
+			DLQMetadataDecoder:       consumer.ProtobufDLQMetadataDecoder,
 			PartitionConsumerFactory: consumer.NewPartitionConsumer,
 		})
 	}

--- a/consumerOptions_test.go
+++ b/consumerOptions_test.go
@@ -36,7 +36,6 @@ func TestDLQConsumerOptions(t *testing.T) {
 	options := consumer.DefaultOptions()
 	consumerOption.apply(options)
 	assert.Equal(t, 2, len(options.OtherConsumerTopics))
-	assert.Equal(t, consumer.TopicTypeDLQ, options.OtherConsumerTopics[0].TopicType)
 }
 
 func TestRetryConsumerOptions(t *testing.T) {
@@ -47,5 +46,4 @@ func TestRetryConsumerOptions(t *testing.T) {
 	options := consumer.DefaultOptions()
 	consumerOption.apply(options)
 	assert.Equal(t, 2, len(options.OtherConsumerTopics))
-	assert.Equal(t, consumer.TopicTypeRetryQ, options.OtherConsumerTopics[0].TopicType)
 }

--- a/internal/consumer/clusterConsumer_test.go
+++ b/internal/consumer/clusterConsumer_test.go
@@ -85,7 +85,7 @@ func (s *ClusterConsumerTestSuite) SetupTest() {
 	s.msgCh = make(chan kafka.Message, 10)
 	s.saramaConsumer = newMockSaramaConsumer()
 	s.dlqProducer = newMockDLQProducer()
-	s.topicConsumer = NewTopicConsumer(Topic{ConsumerTopic: topic, TopicType: TopicTypeDefaultQ, PartitionConsumerFactory: NewPartitionConsumer}, s.msgCh, s.saramaConsumer, s.dlqProducer, s.options, tally.NoopScope, s.logger)
+	s.topicConsumer = NewTopicConsumer(Topic{ConsumerTopic: topic, DLQMetadataDecoder: NoopDLQMetadataDecoder, PartitionConsumerFactory: NewPartitionConsumer}, s.msgCh, s.saramaConsumer, s.dlqProducer, s.options, tally.NoopScope, s.logger)
 	s.consumer = NewClusterConsumer(topic.Cluster, s.saramaConsumer, map[string]*TopicConsumer{s.topic: s.topicConsumer}, tally.NoopScope, s.logger)
 }
 

--- a/internal/consumer/partitionConsumer_test.go
+++ b/internal/consumer/partitionConsumer_test.go
@@ -53,7 +53,7 @@ func (s *RangePartitionConsumerTestSuite) SetupTest() {
 	s.saramaPartitionConsumer = newMockPartitionedConsumer("topic", 0, 100, 5)
 	topic := new(Topic)
 	topic.Name = "topic"
-	topic.TopicType = TopicTypeDefaultQ
+	topic.DLQMetadataDecoder = NoopDLQMetadataDecoder
 	opts := DefaultOptions()
 	l := zap.NewNop()
 	s.partitionConsumer = newPartitionConsumer(

--- a/internal/consumer/types.go
+++ b/internal/consumer/types.go
@@ -31,15 +31,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const (
-	// TopicTypeDefaultQ is an enum for a consumer that reads from a the default/original topic.
-	TopicTypeDefaultQ TopicType = iota + 1
-	// TopicTypeRetryQ is a enum for a consumer that reads from a RetryQ topic.
-	TopicTypeRetryQ
-	// TopicTypeDLQ is a enum for a consumer that reads from a DLQ topic.
-	TopicTypeDLQ
-)
-
 type (
 	// SaramaConsumer is an interface for external consumer library (sarama)
 	SaramaConsumer interface {
@@ -83,9 +74,6 @@ type (
 		NewSaramaClient   func([]string, *sarama.Config) (sarama.Client, error)
 	}
 
-	// TopicType is an enum for the type of topic: TopicTypeDefaultQ, TopicTypeRetryQ, TopicTypeDLQ.
-	TopicType int
-
 	// Topic is an internal wrapper around kafka.ConsumerTopic
 	Topic struct {
 		kafka.ConsumerTopic
@@ -112,20 +100,6 @@ func ProtobufDLQMetadataDecoder(b []byte) (*DLQMetadata, error) {
 		return nil, err
 	}
 	return dlqMetadata, nil
-}
-
-// String converts the TopicType enum to a human readable string.
-func (t TopicType) String() string {
-	switch t {
-	case TopicTypeDefaultQ:
-		return "defaultQ"
-	case TopicTypeRetryQ:
-		return "retryQ"
-	case TopicTypeDLQ:
-		return "DLQ"
-	default:
-		return "invalid"
-	}
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaler for structured logging.

--- a/internal/consumer/types.go
+++ b/internal/consumer/types.go
@@ -21,6 +21,8 @@
 package consumer
 
 import (
+	"errors"
+
 	"github.com/Shopify/sarama"
 	"github.com/bsm/sarama-cluster"
 	"github.com/golang/protobuf/proto"
@@ -103,6 +105,9 @@ func NoopDLQMetadataDecoder(b []byte) (*DLQMetadata, error) {
 // ProtobufDLQMetadataDecoder uses proto.Unmarshal to decode protobuf encoded binary into the DLQMetadata object.
 func ProtobufDLQMetadataDecoder(b []byte) (*DLQMetadata, error) {
 	dlqMetadata := newDLQMetadata()
+	if b == nil {
+		return nil, errors.New("expected to decode non-nil byte array to DLQ metadata")
+	}
 	if err := proto.Unmarshal(b, dlqMetadata); err != nil {
 		return nil, err
 	}

--- a/internal/consumer/types_test.go
+++ b/internal/consumer/types_test.go
@@ -71,6 +71,12 @@ func TestProtobufDLQMetadataDecoder(t *testing.T) {
 	decodedDLQMetadata, err := ProtobufDLQMetadataDecoder(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, dlqMetadata, decodedDLQMetadata)
+
+	_, err = ProtobufDLQMetadataDecoder(nil)
+	assert.Error(t, err)
+
+	_, err = ProtobufDLQMetadataDecoder([]byte{1, 2, 3, 4})
+	assert.Error(t, err)
 }
 
 func TestNoopDLQMetadataDecoder(t *testing.T) {

--- a/internal/consumer/types_test.go
+++ b/internal/consumer/types_test.go
@@ -24,8 +24,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSaramaConsumer(t *testing.T) {

--- a/internal/consumer/types_test.go
+++ b/internal/consumer/types_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/golang/protobuf/proto"
 )
 
 func TestSaramaConsumer(t *testing.T) {
@@ -61,4 +62,23 @@ func TestSaramaClient(t *testing.T) {
 	// Second close should return no error and not increment closed counter
 	assert.NoError(t, c.Close())
 	assert.EqualValues(t, 1, atomic.LoadInt32(&mock.closed))
+}
+
+func TestProtobufDLQMetadataDecoder(t *testing.T) {
+	dlqMetadata := newDLQMetadata()
+	b, err := proto.Marshal(dlqMetadata)
+	assert.NoError(t, err)
+	decodedDLQMetadata, err := ProtobufDLQMetadataDecoder(b)
+	assert.NoError(t, err)
+	assert.EqualValues(t, dlqMetadata, decodedDLQMetadata)
+}
+
+func TestNoopDLQMetadataDecoder(t *testing.T) {
+	dlqMetadata := newDLQMetadata()
+	dlqMetadata.Offset = 100
+	b, err := proto.Marshal(dlqMetadata)
+	assert.NoError(t, err)
+	decodedDLQMetadata, err := NoopDLQMetadataDecoder(b)
+	assert.NoError(t, err)
+	assert.EqualValues(t, newDLQMetadata(), decodedDLQMetadata)
 }


### PR DESCRIPTION
We previously inferred whether to decode DLQ metadata based on `TopicType`. This created confusion because it was not clear which set of behavior depends on `TopicType`. 

This change removes `TopicType` and uses a factory function to decode `DLQMetadata`. The builder injects the appropriate factory function when creating `consumer.Topic` making the behavior much more explicit. 