### PR TITLE
add topic Delay to partitionConsumer

### DIFF
--- a/consumerBuilder_test.go
+++ b/consumerBuilder_test.go
@@ -157,7 +157,7 @@ func (s *ConsumerBuilderTestSuite) TestBuild() {
 		sort.Strings(output)
 		return output
 	}())
-	// make sure retry topic got populated to the read topic list
+	// make sure retry topic with delay gets populated to the read topic list
 	s.Equal([]string{"retry-topic"}, func() []string {
 		output := make([]string, 0, 1)
 		for _, topicList := range s.builder.clusterTopicsMap {

--- a/consumerBuilder_test.go
+++ b/consumerBuilder_test.go
@@ -23,6 +23,7 @@ package kafkaclient
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/bsm/sarama-cluster"
@@ -31,7 +32,6 @@ import (
 	"github.com/uber-go/kafka-client/kafka"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
-	"time"
 )
 
 type (
@@ -66,9 +66,9 @@ func (s *ConsumerBuilderTestSuite) SetupTest() {
 				Cluster: "cluster",
 			},
 			RetryQ: kafka.Topic{
-				Name:       "retry-topic",
-				Cluster:    "dlq-cluster",
-				RetryDelay: time.Microsecond,
+				Name:    "retry-topic",
+				Cluster: "dlq-cluster",
+				Delay:   time.Microsecond,
 			},
 			DLQ: kafka.Topic{
 				Name:    "dlq-topic",
@@ -162,7 +162,7 @@ func (s *ConsumerBuilderTestSuite) TestBuild() {
 		output := make([]string, 0, 1)
 		for _, topicList := range s.builder.clusterTopicsMap {
 			for _, topic := range topicList {
-				if topic.RetryDelay > 0 {
+				if topic.Delay > 0 {
 					output = append(output, topic.Name)
 				}
 			}

--- a/internal/consumer/partitionConsumer.go
+++ b/internal/consumer/partitionConsumer.go
@@ -256,16 +256,17 @@ func (p *partitionConsumer) messageLoop(offsetRange *kafka.OffsetRange) {
 	}
 }
 
-// delayMsg try to postpone the consumption of the msg for topic.Delay duration if the current timestamp
-// is too soon compare to the msg.Timestamp when Topic.Delay is not zero.
+// delayMsg when Topic.Delay is not zero, it try to postpone the consumption of the msg for topic.Delay duration
+// if the current timestamp is too soon compare to the msg.Timestamp.
 func (p *partitionConsumer) delayMsg(timestamp time.Time) {
 	delay := p.topicPartition.Delay
 	// check non-zero msg delay
 	if delay > 0 {
-		lag := time.Now().Sub(timestamp)
-		p.logger.Debug("delay msg deliver for topic", zap.String("topic", p.topicPartition.Name),
-			zap.Duration("sleep delay", delay-lag))
-		time.Sleep(delay - lag)
+		sleepDuration := delay + timestamp.Sub(time.Now())
+		if sleepDuration > 0 {
+			p.logger.Debug("delay msg delivery", zap.Duration("sleepDuration", sleepDuration))
+			time.Sleep(sleepDuration)
+		}
 	}
 }
 

--- a/internal/consumer/partitionConsumer_test.go
+++ b/internal/consumer/partitionConsumer_test.go
@@ -73,7 +73,7 @@ func (s *RangePartitionConsumerTestSuite) TestDelayMsg() {
 	t1 := time.Now()
 	delay := time.Millisecond
 	s.rangePartitionConsumer.topicPartition.Delay = delay
-	s.rangePartitionConsumer.delayMsg(time.Duration(0))
+	s.rangePartitionConsumer.delayMsg(t1)
 	t2 := time.Now()
 	if t2.Sub(t1) < delay {
 		s.Fail("expect to sleep around " + delay.String())
@@ -81,7 +81,7 @@ func (s *RangePartitionConsumerTestSuite) TestDelayMsg() {
 
 	// lag > delay, almost return immediately
 	t1 = time.Now()
-	s.rangePartitionConsumer.delayMsg(time.Millisecond * 2)
+	s.rangePartitionConsumer.delayMsg(t1.Add(time.Millisecond * -3))
 	t2 = time.Now()
 	if t2.Sub(t1) > time.Millisecond {
 		s.Fail("expect no delay on msg, actual time cost is " + t2.Sub(t1).String())
@@ -90,7 +90,7 @@ func (s *RangePartitionConsumerTestSuite) TestDelayMsg() {
 	// delay = 0, almost return immediately
 	t1 = time.Now()
 	s.rangePartitionConsumer.topicPartition.Delay = 0
-	s.rangePartitionConsumer.delayMsg(time.Millisecond * 2)
+	s.rangePartitionConsumer.delayMsg(t1.Add(time.Millisecond))
 	t2 = time.Now()
 	if t2.Sub(t1) > time.Millisecond {
 		s.Fail("expect no delay on msg")

--- a/internal/consumer/partitionConsumer_test.go
+++ b/internal/consumer/partitionConsumer_test.go
@@ -69,6 +69,34 @@ func (s *RangePartitionConsumerTestSuite) SetupTest() {
 	s.rangePartitionConsumer = newRangePartitionConsumer(s.partitionConsumer)
 }
 
+func (s *RangePartitionConsumerTestSuite) TestDelayMsg() {
+	t1 := time.Now()
+	delay := time.Millisecond
+	s.rangePartitionConsumer.topicPartition.Delay = delay
+	s.rangePartitionConsumer.delayMsg(time.Duration(0))
+	t2 := time.Now()
+	if t2.Sub(t1) < delay {
+		s.Fail("expect to sleep around " + delay.String())
+	}
+
+	// lag > delay, almost return immediately
+	t1 = time.Now()
+	s.rangePartitionConsumer.delayMsg(time.Millisecond * 2)
+	t2 = time.Now()
+	if t2.Sub(t1) > time.Millisecond {
+		s.Fail("expect no delay on msg, actual time cost is " + t2.Sub(t1).String())
+	}
+
+	// delay = 0, almost return immediately
+	t1 = time.Now()
+	s.rangePartitionConsumer.topicPartition.Delay = 0
+	s.rangePartitionConsumer.delayMsg(time.Millisecond * 2)
+	t2 = time.Now()
+	if t2.Sub(t1) > time.Millisecond {
+		s.Fail("expect no delay on msg")
+	}
+}
+
 func (s *RangePartitionConsumerTestSuite) TestOffsetNotificationTriggersMessageConsuming() {
 	s.rangePartitionConsumer.Start()
 

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -22,9 +22,10 @@ package kafka
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap/zapcore"
-	"time"
 )
 
 const (

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap/zapcore"
+	"time"
 )
 
 const (
@@ -45,6 +46,8 @@ type (
 		// If this is empty, we will get the broker list using the NameResolver
 		// TODO (gteo): remove this and rely on a NameResolver as single source for broker IP
 		BrokerList []string
+		// RetryDelay, msg diliver delay duration for retryTopic;
+		RetryDelay time.Duration
 	}
 
 	// ConsumerTopic contains information for a consumer topic.
@@ -140,6 +143,7 @@ func (c ConsumerTopic) MarshalLogObject(e zapcore.ObjectEncoder) error {
 func (t Topic) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddString("name", t.Name)
 	e.AddString("cluster", t.Cluster)
+	e.AddDuration("retryDelay", t.RetryDelay)
 	return nil
 }
 

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -46,8 +46,8 @@ type (
 		// If this is empty, we will get the broker list using the NameResolver
 		// TODO (gteo): remove this and rely on a NameResolver as single source for broker IP
 		BrokerList []string
-		// RetryDelay, msg diliver delay duration for retryTopic;
-		RetryDelay time.Duration
+		// Delay is msg consumption delay applied on the topic.
+		Delay time.Duration
 	}
 
 	// ConsumerTopic contains information for a consumer topic.
@@ -143,7 +143,7 @@ func (c ConsumerTopic) MarshalLogObject(e zapcore.ObjectEncoder) error {
 func (t Topic) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddString("name", t.Name)
 	e.AddString("cluster", t.Cluster)
-	e.AddDuration("retryDelay", t.RetryDelay)
+	e.AddDuration("delay", t.Delay)
 	return nil
 }
 


### PR DESCRIPTION
add a Delay member to the Topic struct to enable pass retry delay duration specified by the consumer. The Delay value is specified at the topic initialization stage. The partitionConsumer Thread will check the Delay value and sleep around Delay duration before deliver the msg to the output channel.