### PR TITLE
Fix reset offset on rebalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v0.1.4 (unreleased)
 
 - Fix DLQMetadata decoding to use DLQMetadataDecoder func instead of inferred decoding from TopicType.
 - Fix consumer to use noopDLQ if RetryQ or DLQ in config is empty.
+- Fix ResetOffset fails on partition rebalance.
 
 
 v0.1.3 (2018-03-09)

--- a/internal/consumer/partitionConsumer.go
+++ b/internal/consumer/partitionConsumer.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -36,7 +37,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"sync"
 )
 
 type (

--- a/internal/consumer/partitionConsumer_test.go
+++ b/internal/consumer/partitionConsumer_test.go
@@ -149,3 +149,19 @@ func (s *RangePartitionConsumerTestSuite) TestOffsetNotificationTriggersMessageC
 	s.EqualValues(92, s.rangePartitionConsumer.ackMgr.CommitLevel())
 	s.rangePartitionConsumer.Stop()
 }
+
+func (s *RangePartitionConsumerTestSuite) TestResetOffsetNoHighOffsetReturnsError() {
+	s.Error(s.rangePartitionConsumer.ResetOffset(kafka.OffsetRange{LowOffset: 90, HighOffset: -1}))
+}
+
+func (s *RangePartitionConsumerTestSuite) TestResetOffsetStoppedReturnsError() {
+	close(s.rangePartitionConsumer.stopC)
+	s.Error(s.rangePartitionConsumer.ResetOffset(kafka.OffsetRange{LowOffset: 90, HighOffset: 100}))
+}
+
+func (s *RangePartitionConsumerTestSuite) TestResetOffsetWithCurrentOffsetReturnsNil() {
+	s.rangePartitionConsumer.offsetRangeLock.Lock()
+	s.rangePartitionConsumer.offsetRange = &kafka.OffsetRange{LowOffset: 90, HighOffset: 100}
+	s.rangePartitionConsumer.offsetRangeLock.Unlock()
+	s.NoError(s.rangePartitionConsumer.ResetOffset(kafka.OffsetRange{LowOffset: 95, HighOffset: 100}))
+}


### PR DESCRIPTION
RangePartitionConsumer cache last set reset offset to ensure that multiple calls to reset offset does not trigger another reset offset. 