### PR TITLE
Fix OffsetNewest to apply for non retry and dlq topics only

### DIFF
--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -54,7 +54,7 @@ type (
 
 	consumerCluster struct {
 		name         string
-		offsetPolicy int64
+		initialOffset int64
 	}
 )
 
@@ -135,7 +135,7 @@ func (c *consumerBuilder) build() (*consumer.MultiClusterConsumer, error) {
 	clusterConsumerMap := make(map[string]*consumer.ClusterConsumer)
 	for cluster, topicList := range c.clusterTopicsMap {
 		uniqueTopicList := c.uniqueTopics(topicList)
-		saramaConsumer, err := c.getOrAddSaramaConsumer(cluster.name, uniqueTopicList, cluster.offsetPolicy)
+		saramaConsumer, err := c.getOrAddSaramaConsumer(cluster.name, uniqueTopicList, cluster.initialOffset)
 		if err != nil {
 			c.close()
 			return nil, err

--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -52,8 +52,11 @@ type (
 		saramaClusterConfig *cluster.Config
 	}
 
+	// consumerCluster wraps a consumer cluster name and relevant config for consuming from that cluster.
 	consumerCluster struct {
-		name          string
+		// name is the name of the cluster.
+		name string
+		// initialOffset is the initial offset of the cluster if there is no previously checkpointed offset.
 		initialOffset int64
 	}
 )

--- a/consumerBuilder.go
+++ b/consumerBuilder.go
@@ -53,7 +53,7 @@ type (
 	}
 
 	consumerCluster struct {
-		name         string
+		name          string
 		initialOffset int64
 	}
 )

--- a/consumerBuilder_test.go
+++ b/consumerBuilder_test.go
@@ -125,7 +125,7 @@ func (s *ConsumerBuilderTestSuite) TestBuild() {
 	s.Equal([]string{"cluster", "dlq-cluster"}, func() []string {
 		output := make([]string, 0, 3)
 		for cluster := range s.builder.clusterTopicsMap {
-			output = append(output, cluster)
+			output = append(output, cluster.name)
 		}
 		sort.Strings(output)
 		return output

--- a/consumerOptions.go
+++ b/consumerOptions.go
@@ -31,10 +31,6 @@ type (
 		apply(*consumer.Options)
 	}
 
-	rangeConsumersOption struct {
-		topicList kafka.ConsumerTopicList
-	}
-
 	dlqTopicsOptions struct {
 		topicList kafka.ConsumerTopicList
 	}
@@ -43,24 +39,6 @@ type (
 		topicList kafka.ConsumerTopicList
 	}
 )
-
-// WithRangeConsumers creates a range consumer for the specified consumer topics.
-// DEPRECATED
-func WithRangeConsumers(topicList kafka.ConsumerTopicList) ConsumerOption {
-	return &rangeConsumersOption{
-		topicList: topicList,
-	}
-}
-
-func (o *rangeConsumersOption) apply(opts *consumer.Options) {
-	for _, topic := range o.topicList {
-		opts.OtherConsumerTopics = append(opts.OtherConsumerTopics, consumer.Topic{
-			ConsumerTopic:            topic,
-			DLQMetadataDecoder:       consumer.NoopDLQMetadataDecoder,
-			PartitionConsumerFactory: consumer.NewRangePartitionConsumer,
-		})
-	}
-}
 
 // WithDLQTopics creates a range consumer for the specified consumer DLQ topics.
 func WithDLQTopics(topicList kafka.ConsumerTopicList) ConsumerOption {

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -88,6 +88,8 @@ type (
 			Commits struct {
 				// Enabled if you want the library to commit offsets on your behalf.
 				// Defaults to true.
+				//
+				// The retry and dlq topic commit will always be committed for you since those topics are abstracted away from you.
 				Enabled bool
 			}
 		}


### PR DESCRIPTION
Since retry and dlq topics should be abstracted away from the user, OffsetNewest policy should only be applied for the original topic. If data is sent to retry or dlq topic, it regular commit and offestOldest policies should be applied to ensure that users expectations of no dataloss when using retry and dlq features is retained. 