### PR TITLE
Pin to sarama cluster without message drain race condition on rebalance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 sudo: false
 go:
   - 1.9
-  - 1.10
 go_import_path: github.com/uber-go/kafka-client
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-  - 1.8
   - 1.9
+  - 1.10
 go_import_path: github.com/uber-go/kafka-client
 cache:
   directories:

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: d6d7552888db6c06b96621ff164834bd6b1f6e588f43c815c0c07e0a1a0cfff0
-updated: 2018-03-07T10:32:31.733217-08:00
+hash: 7d078c7331a4969ce42c6ea7f89b5ec300d3817ad3e1dd11b6538bdea24be3ea
+updated: 2018-08-16T16:34:08.475782281-07:00
 imports:
 - name: github.com/bsm/sarama-cluster
-  version: cf455bc755fe41ac9bb2861e7a961833d9c2ecc3
+  version: abb0e9f5dd57b5a3167e1472136a84c4b989478b
 - name: github.com/davecgh/go-spew
   version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
@@ -15,10 +15,8 @@ imports:
   version: bb955e01b9346ac19dc29eb16586c90ded99a98c
 - name: github.com/eapache/queue
   version: 093482f3f8ce946c05bcba64badd2c82369e084d
-- name: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/protobuf
-  version: 925541529c1fa6821df4e44ce2723319eb2be768
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - proto
 - name: github.com/golang/snappy
@@ -32,15 +30,15 @@ imports:
 - name: github.com/rcrowley/go-metrics
   version: 8732c616f52954686704c8645fe1a9d59e9df7c1
 - name: github.com/Shopify/sarama
-  version: f7be6aa2bc7b2e38edf816b08b582782194a1c02
+  version: 35324cf48e33d8260e1c7c18854465a904ade249
 - name: github.com/uber-go/tally
-  version: 522328b48efad0c6034dba92bf39228694e9d31f
+  version: ff17f3c43c065c3c2991f571e740eee43ea3a14a
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  version: ff33455a0e382e8a81d14dd7c922020b6b5e7982
   subpackages:
   - buffer
   - internal/bufferpool
@@ -53,7 +51,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/Shopify/sarama
   version: ^1
 - package: github.com/bsm/sarama-cluster
-  version: ~2.1.13
+  version: abb0e9f5dd57b5a3167e1472136a84c4b989478b
 - package: github.com/golang/protobuf
   version: ^1
 testImport:

--- a/internal/consumer/mocks_test.go
+++ b/internal/consumer/mocks_test.go
@@ -284,6 +284,18 @@ func (m *mockPartitionedConsumer) Partition() int32 {
 	return m.id
 }
 
+func (m *mockPartitionedConsumer) InitialOffset() int64 {
+	panic("implement me")
+}
+
+func (m *mockPartitionedConsumer) MarkOffset(offset int64, metadata string) {
+	panic("implement me")
+}
+
+func (m *mockPartitionedConsumer) ResetOffset(offset int64, metadata string) {
+	panic("implement me")
+}
+
 func newMockSaramaConsumer() *mockSaramaConsumer {
 	return &mockSaramaConsumer{
 		errorC:     make(chan error, 1),
@@ -394,6 +406,10 @@ func newMockSaramaClient() *mockSaramaClient {
 	return &mockSaramaClient{
 		closed: 0,
 	}
+}
+
+func (m *mockSaramaClient) Controller() (*sarama.Broker, error) {
+	panic("implement me")
 }
 
 func (m *mockSaramaClient) Config() *sarama.Config {


### PR DESCRIPTION
This change pins to sarama-cluster version with fix for https://github.com/bsm/sarama-cluster/issues/255. This introduces a regression for non partition consumption, which is not a problem for this library. This unblocks users of this library while the regression in sarama-cluster is addressed. 